### PR TITLE
Do not force disable Author archive page

### DIFF
--- a/itineris-prevent-user-enumeration.php
+++ b/itineris-prevent-user-enumeration.php
@@ -46,7 +46,7 @@ add_action('wp', function (): void {
     /** @var WP_Query */
     $wp_query = $GLOBALS['wp_query'];
     $query_vars = $wp_query->query_vars;
-    if (empty($query_vars) || empty($query_vars['author'])) {
+    if (empty($query_vars) || empty($query_vars['author']) || $wp_query->is_author()) {
         return;
     }
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases, this will be possible.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Requires manual action post-deploy
- [ ] Optimisation
- [ ] Documentation update

## Description

Do not force disable author archive page. If you want to disable archive page, go to Yoast Settings -> Advanced -> Author archives and check if author archives are disabled (is disabled by default)

![image](https://github.com/user-attachments/assets/9df8590c-7c68-46cf-8002-1fb9920ae0fd)
