### PR TITLE
the_author-references

### DIFF
--- a/itineris-prevent-user-enumeration.php
+++ b/itineris-prevent-user-enumeration.php
@@ -21,7 +21,10 @@ if (! defined('WPINC')) {
 add_filter('login_errors', function (string $errors): string {
     if (isset($GLOBALS['errors']) && $GLOBALS['errors'] instanceof WP_Error) {
         $error_codes = $GLOBALS['errors']->get_error_codes();
-        if (! in_array('invalid_username', $error_codes, true) && ! in_array('incorrect_password', $error_codes, true)) {
+        if (
+            ! in_array('invalid_username', $error_codes, true) &&
+            ! in_array('incorrect_password', $error_codes, true)
+        ) {
             return $errors;
         }
     } else {


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases, this will be possible.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Requires manual action post-deploy
- [ ] Optimisation
- [ ] Documentation update

## Description

Removes references to usernames in `the_author` and `get_the_author` calls.
It will attempt to use other profile properties like nicename, nickname, first and last names.
If none are suitable, it will simply return `REDACTED` since all other options would expose the username.

## QA Instructions, Screenshots, Recordings

Check anywhere that calls `the_author or `get_the_author`
e.g. https://base.itineris.dev/feed/